### PR TITLE
Fixed sh: Size: unknown operand error due to command substitution issue…

### DIFF
--- a/buildroot/board/meraki/ms200/overlay/etc/init.d/S10meraki
+++ b/buildroot/board/meraki/ms200/overlay/etc/init.d/S10meraki
@@ -19,7 +19,11 @@ start() {
     fi
 
     sysctl -w net.ipv4.ip_local_reserved_ports=50000-50127
-    if [ $(lsmod | grep -v vc_click) -eq 0 ]; then
+
+    # Check to see if vc_click module has loaded
+    lsmod | grep -q vc_click
+
+    if [ $? -ne 0 ]; then
         echo "vc_click isn't loaded; aborting!"
         exit
     elif [ ! -d /click/client_ip_table ]; then


### PR DESCRIPTION
Doesn't look like BusyBox shell likes command substitution:

```
# $(lsmod | grep -v vc_click)
-sh: Module: not found
```

Changed to run grep silently, and amended the logic on the if statement. 