### PR TITLE
add initial config daemon script

### DIFF
--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -29,110 +29,118 @@ set_vlan() {
 
     vlans=$(cat $CSPT/dump_pport_vlans | grep "^ *$port ")
 
-    echo -e "PORT $port,
+    update=$(echo -e "PORT $port,
             ALLOWED_VLANS          $(echo $vlans | awk '{print $11}'),
             ALLOW_TAGGED_IN        $(echo $vlans | awk '{print $2}'),
             ALLOW_UNTAGGED_IN      $(echo $vlans | awk '{print $3}'),
             INGRESS_FILTER         $(echo $vlans | awk '{print $4}'),
             RADIUS_CAN_ASSIGN_VLAN true,
             PVID                   $(echo $vlans | awk '{print $6}'),
-            UNTAGGED_VID           $(echo $vlans | awk '{print $7}')" \
-      | tr '\n' ' ' \
-      | sed "s|$key [^,]*,|$key $value,|" \
-      > $CSPT/set_vlan_allports_conf
+            UNTAGGED_VID           $(echo $vlans | awk '{print $7}')" |
+        tr '\n' ' ')
+
+    # only update value if changed
+    if [ "$(echo $update | sed -E "s|.* $key ([^,]*),.*|\1|")" != "$value" ]; then
+        echo changing port $port vlan $key to $value
+        echo $update | sed "s|$key [^,]*,|$key $value,|" >$CSPT/set_vlan_allports_conf
+    fi
 }
 
 # update switch settings
 update() {
     for diff in $DIFF; do
-          key=$(echo $diff | sed -E "s|$REGEX|\1|" | tr -d \")
-          value=$(echo $diff | sed -E "s|$REGEX|\2|" | tr -d \")
+        key=$(echo $diff | sed -E "s|$REGEX|\1|" | tr -d \")
+        value=$(echo $diff | sed -E "s|$REGEX|\2|" | tr -d \")
 
-          case $key in
-              device | date)
-                  # NO-OP: user should not be able to modify these fields
-                  ;;
-              ports,*)
-                  port=$(echo $key | cut -d, -f2)
-                  field=$(echo $key | cut -d, -f3)
-                  subfield=$(echo $key | cut -d, -f4)
+        case $key in
+        device | date)
+            # NO-OP: user should not be able to modify these fields
+            ;;
+        ports,*)
+            port=$(echo $key | cut -d, -f2)
+            field=$(echo $key | cut -d, -f3)
+            subfield=$(echo $key | cut -d, -f4)
 
-                  case $field in
-                      port | link | status)
-                          # NO-OP: user should not be able to modify these fields
-                          ;;
-                      enabled)
-                              case $value in
-                                 true)
-                                    echo enable port $port
-                                 ;;
-                                 false)
-                                    echo disable port $port
-                                 ;;
-                                 *)
-                                    echo error: unknown port enable value: $value
-                                 ;;
-                                  esac
-                          ;;
-                      vlan)
-                          case $subfield in
-                              pvid)
-                                  echo changing port $port pvid to $value
-                                  set_vlan $port PVID $value
-                              ;;
-                              allowed)
-                                  echo changing port $port allowed vlans to $value
-                                  set_vlan $port ALLOWED_VLANS $value
-                              ;;
-                              *)
-                                  echo unknown vlan setting: $field for port $port
-                              ;;
-                          esac
-                          ;;
-                      poe)
-                          case $subfield in
-                              enabled)
-                                  case $value in
-                                     true)
-                                        echo enabling poe on port $port
-                                        pd690xx -e $port
-                                     ;;
-                                     false)
-                                        echo disabling poe on port $port
-                                        pd690xx -d $port
-                                     ;;
-                                     *)
-                                        echo error: unknown poe enable value: $value
-                                     ;;
-                                  esac
-                              ;;
-                              mode)
-                                  echo change port $port poe mode to $value
-                                  # TODO: not implemented
-                              ;;
-                              *)
-                                  echo unknown poe setting: $field for port $port
-                              ;;
-                          esac
-                          ;;
-                      lacp)
-                          echo change port $port lacp to $value
-                          ;;
-                      stp)
-                          echo change port $port stp to $value
-                          ;;
-                      *)
-                          echo unknown field: $field for port $port with value = $value
-                          ;;
-                  esac
-                  ;;
-          esac
+            case $field in
+            port | link | status)
+                # NO-OP: user should not be able to modify these fields
+                ;;
+            enabled)
+                # TODO
+                echo "change port $port enabled to $value (not implemented)"
+                ;;
+            lacp)
+                # TODO: maybe $CSPT/enable_lacp_on_single_ports
+                echo "change port $port stp to $value (not implemented)"
+                ;;
+            stp)
+                # TODO: probably something with $CSPT/set_ports_stp_state
+                # echo -e "PORT $MAC/$i, ENABLED true, AUTOEDGE true, EDGE false, AUTOPTP true, PTP false, PRI 128, COST 0" > /click/stp/set_many_port_cfgs
+                echo "change port $port stp to $value (not implemented)"
+                ;;
+            vlan)
+                case $subfield in
+                pvid)
+                    set_vlan $port PVID $value
+                    ;;
+                allowed)
+                    set_vlan $port ALLOWED_VLANS $value
+                    ;;
+                tag_in)
+                    set_vlan $port ALLOW_TAGGED_IN $value
+                    ;;
+                untag_in)
+                    set_vlan $port ALLOW_UNTAGGED_IN $value
+                    ;;
+                *)
+                    echo "error: unknown vlan setting: $subfield for port $port"
+                    ;;
+                esac
+                ;;
+            poe)
+                case $subfield in
+                power)
+                    # NO-OP: user should not be able to modify these fields
+                    ;;
+                enabled)
+                    case $value in
+                    true)
+                        if [ $(pd690xx -l | grep "^ *$port\s" | grep "Disabled") ]; then
+                            echo enabling poe on port $port
+                            pd690xx -e $port
+                        fi
+                        ;;
+                    false)
+                        if [ $(pd690xx -l | grep "^ *$port\s" | grep "Enabled") ]; then
+                            echo disabling poe on port $port
+                            pd690xx -d $port
+                        fi
+                        ;;
+                    *)
+                        echo "error: unknown poe enable value: $value"
+                        ;;
+                    esac
+                    ;;
+                mode | standard)
+                    # TODO: not implemented
+                    echo "change port $port poe mode to $value (not implemented)"
+                    ;;
+                *)
+                    echo "error: unknown poe setting $subfield for port $port"
+                    ;;
+                esac
+                ;;
+            *)
+                echo "error: unknown field $field for port $port with value = $value"
+                ;;
+            esac
+            ;;
+        esac
     done
 
     # update serialized cache file
-    serialize $CONFIG > $CACHE
+    serialize $CONFIG >$CACHE
 }
-
 
 # main loop
 while true; do

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -1,0 +1,119 @@
+#!/usr/bin/env sh
+#
+# daemon to watch /etc/switch.json for changes
+#
+
+# source of truth
+CONFIG=/etc/switch.json
+# cache file to diff changes
+CACHE=/etc/.switch.cache.json
+[ -f $CACHE ] || touch $CACHE
+
+# regex which defines json serialization pattern and capture groups
+#   1) key
+#   2) value
+REGEX='^\+\[\[(.*)\],(.*)\]'
+
+# serialize json into lines of [<key>,<value>] for easy diffing
+serialize() {
+    jq -c 'path(.. | select(type | IN(["object","array"][]) | not)) as $path | [$path,getpath($path)]' $1
+}
+
+# update switch settings
+update() {
+    for diff in $DIFF; do
+          key=$(echo $diff | sed -E "s|$REGEX|\1|" | tr -d \")
+          value=$(echo $diff | sed -E "s|$REGEX|\2|" | tr -d \")
+
+          case $key in
+              device | date)
+                  # NO-OP: user should not be able to modify these fields
+                  ;;
+              ports,*)
+                  port=$(expr 1 + $(echo $key | cut -d, -f2))
+                  field=$(echo $key | cut -d, -f3)
+                  subfield=$(echo $key | cut -d, -f4)
+
+                  case $field in
+                      port | link | status)
+                          # NO-OP: user should not be able to modify these fields
+                          ;;
+                      enabled)
+                              case $value in
+                                 true)
+                                    echo enable port $port
+                                 ;;
+                                 false)
+                                    echo disable port $port
+                                 ;;
+                                 *)
+                                    echo error: unknown port enable value: $value
+                                 ;;
+                                  esac
+                          ;;
+                      vlan)
+                          case $subfield in
+                              pvid)
+                                  echo change port $port pvid to $value
+                              ;;
+                              mode)
+                                  echo change port $port allowed vlans to $value
+                              ;;
+                              *)
+                                  echo unknown vlan setting: $field for port $port
+                              ;;
+                          esac
+                          ;;
+                      poe)
+                          case $subfield in
+                              enabled)
+                                  case $value in
+                                     true)
+                                        echo enabling poe on port $port
+                                        pd690xx -e $port
+                                     ;;
+                                     false)
+                                        echo disabling poe on port $port
+                                        pd690xx -d $port
+                                     ;;
+                                     *)
+                                        echo error: unknown poe enable value: $value
+                                     ;;
+                                  esac
+                              ;;
+                              mode)
+                                  echo change port $port poe mode to $value
+                              ;;
+                              *)
+                                  echo unknown poe setting: $field for port $port
+                              ;;
+                          esac
+                          ;;
+                      lacp)
+                          echo change port $port lacp to $value
+                          ;;
+                      stp)
+                          echo change port $port stp to $value
+                          ;;
+                      *)
+                          echo unknown field: $field for port $port with value = $value
+                          ;;
+                  esac
+                  ;;
+          esac
+    done
+
+    # update serialized cache file
+    serialize $CONFIG > $CACHE
+}
+
+
+# main loop
+while true; do
+    DIFF=$(serialize $CONFIG | diff -U0 $CACHE - | tail -n +4 | grep '^\+')
+    if [ -n "$DIFF" ]; then
+        update
+    fi
+
+    sleep 10
+done

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -30,7 +30,7 @@ update() {
                   # NO-OP: user should not be able to modify these fields
                   ;;
               ports,*)
-                  port=$(expr 1 + $(echo $key | cut -d, -f2))
+                  port=$(echo $key | cut -d, -f2)
                   field=$(echo $key | cut -d, -f3)
                   subfield=$(echo $key | cut -d, -f4)
 

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -66,11 +66,23 @@ update() {
                 # NO-OP: user should not be able to modify these fields
                 ;;
             enabled)
-                # TODO
-                echo "change port $port enabled to $value (not implemented)"
+                case $value in
+                true)
+                    echo "enabling port $port"
+                    echo "PORT $port, MODE aneg" >$CSPT/set_port_phy_cfgs
+                    ;;
+                false)
+                    echo "disabling port $port"
+                    echo "PORT $port, MODE off" >$CSPT/set_port_phy_cfgs
+                    ;;
+                *)
+                    echo "error: invalid port enabled value for port $port: $value"
+                    ;;
+                esac
                 ;;
             lacp)
-                # TODO: maybe $CSPT/enable_lacp_on_single_ports
+                # TODO
+                # echo "AGGR 0, MEMBERS '9,10'" >$CSPT/add_link_aggr
                 echo "change port $port stp to $value (not implemented)"
                 ;;
             stp)

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -62,7 +62,7 @@ update() {
             subfield=$(echo $key | cut -d, -f4)
 
             case $field in
-            port | link | status)
+            port | status)
                 # NO-OP: user should not be able to modify these fields
                 ;;
             enabled)
@@ -89,6 +89,32 @@ update() {
                 # TODO: probably something with $CSPT/set_ports_stp_state
                 # echo -e "PORT $MAC/$i, ENABLED true, AUTOEDGE true, EDGE false, AUTOPTP true, PTP false, PRI 128, COST 0" > /click/stp/set_many_port_cfgs
                 echo "change port $port stp to $value (not implemented)"
+                ;;
+            link)
+                case $subfield in
+                speed)
+                    case $value in
+                    0)
+                        echo "removed forced speed for port $port"
+                        # TODO: should use port enabled value
+                        echo "PORT $port, MODE aneg" >$CSPT/set_port_phy_cfgs
+                        ;;
+                    100 | 1000 | 10000)
+                        echo "forcing port $port speed at $value"
+                        echo "PORT $port, MODE forced, FORCE_SPEED ${value}fdx" >$CSPT/set_port_phy_cfgs
+                        ;;
+                    *)
+                        echo "error: invalid forced port speed for port $port: $value"
+                        ;;
+                    esac
+                    ;;
+                established)
+                    # NO-OP: user should not be able to modify these fields
+                    ;;
+                *)
+                    echo "error: unknown link setting for port $port: $subfield"
+                    ;;
+                esac
                 ;;
             vlan)
                 case $subfield in

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -14,9 +14,32 @@ CACHE=/tmp/.switch.cache.json
 #   2) value
 REGEX='^\+\[\[(.*)\],(.*)\]'
 
+CSPT=/click/switch_port_table
+
 # serialize json into lines of [<key>,<value>] for easy diffing
 serialize() {
     jq -c 'path(.. | select(type | IN(["object","array"][]) | not)) as $path | [$path,getpath($path)]' $1
+}
+
+# set vlan <key> of <port> to <value>
+set_vlan() {
+    port=$1
+    key=$2
+    value=$3
+
+    vlans=$(cat $CSPT/dump_pport_vlans | grep "^ *$port ")
+
+    echo -e "PORT $port,
+            ALLOWED_VLANS          $(echo $vlans | awk '{print $11}'),
+            ALLOW_TAGGED_IN        $(echo $vlans | awk '{print $2}'),
+            ALLOW_UNTAGGED_IN      $(echo $vlans | awk '{print $3}'),
+            INGRESS_FILTER         $(echo $vlans | awk '{print $4}'),
+            RADIUS_CAN_ASSIGN_VLAN true,
+            PVID                   $(echo $vlans | awk '{print $6}'),
+            UNTAGGED_VID           $(echo $vlans | awk '{print $7}')" \
+      | tr '\n' ' ' \
+      | sed "s|$key [^,]*,|$key $value,|" \
+      > $CSPT/set_vlan_allports_conf
 }
 
 # update switch settings
@@ -54,10 +77,12 @@ update() {
                       vlan)
                           case $subfield in
                               pvid)
-                                  echo change port $port pvid to $value
+                                  echo changing port $port pvid to $value
+                                  set_vlan $port PVID $value
                               ;;
-                              mode)
-                                  echo change port $port allowed vlans to $value
+                              allowed)
+                                  echo changing port $port allowed vlans to $value
+                                  set_vlan $port ALLOWED_VLANS $value
                               ;;
                               *)
                                   echo unknown vlan setting: $field for port $port
@@ -83,6 +108,7 @@ update() {
                               ;;
                               mode)
                                   echo change port $port poe mode to $value
+                                  # TODO: not implemented
                               ;;
                               *)
                                   echo unknown poe setting: $field for port $port

--- a/buildroot/board/meraki/ms220/overlay/bin/configd
+++ b/buildroot/board/meraki/ms220/overlay/bin/configd
@@ -6,7 +6,7 @@
 # source of truth
 CONFIG=/etc/switch.json
 # cache file to diff changes
-CACHE=/etc/.switch.cache.json
+CACHE=/tmp/.switch.cache.json
 [ -f $CACHE ] || touch $CACHE
 
 # regex which defines json serialization pattern and capture groups


### PR DESCRIPTION
Initial shell script daemon to poll `/etc/switch.json` for changes. Intended to manage the config describe in #2 and eventually be the backend for #3.

Currently, only PoE enable/disable is implemented as a proof of concept.

The following steps should work for testing.
1. generate the `switch.json` file:
```sh
switch_status | jq > /etc/switch.json
```
2. execute the script: `./configd` (first time will take a minute, depending on number of ports)
3. edit `/etc/switch.json`
4. wait up to 10s for change to be made

Implemented:
- [x] enabled
- [ ] lacp
- [ ] stp
- [x] forced link speed
- poe
  - [x] enabled
  - [ ] mode
- vlan
  - [x] pvid
  - [x] allowed
  - [x] tag_in
  - [x] untag_in