### PR TITLE
add script to update firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ After building the toolchain + target filesystem with `make`, copy `output/image
 * Copy `buildroot/board/meraki/mx80/buildroot-config` to `.config` in your extracted buildroot directory
 * Copy `buildroot/board/merkai/mx80` to `board/meraki/mx80` in your buildroot tree
 * Run `make` to build buildroot, the bootable/flashable image can be found in `output/images/ubi_image.bin`
+
+
+# Firmware update
+
+* download the latest release and copy it to your device
+* execute `fw_upgrade ./postmerkOS-YYYYMMDD.bin`
+* once flashed, the device will reboot to the updated firmware image

--- a/buildroot/board/meraki/ms220/overlay/bin/fw_upgrade
+++ b/buildroot/board/meraki/ms220/overlay/bin/fw_upgrade
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+if [ ! -n "$1" ]; then
+  echo "error: must pass path to firmware bin or squashfs"
+  echo "usage: $0 ./path/to/firmware.bin"
+  exit 1
+fi
+FILE="$1"
+
+case "$FILE" in
+  *.bin)
+    # extract sqaushfs from bin
+    tmp=$(mktemp squashfs.XXXXXX)
+    busybox dd if="$FILE" bs=1M skip=3 count=8 of="$tmp"
+    FILE="$tmp"
+  ;;
+  *.squashfs)
+    # copy to /tmp, if not already there
+    case "$(realpath $FILE)" in
+      /tmp/*)
+      ;;
+      *)
+        cp "$FILE" /tmp/
+      ;;
+    esac
+  ;;
+  *)
+    echo "error: cannot determine input filetype; must have .bin or .squashfs suffix"
+    exit 1
+  ;;
+esac
+
+cp -f /bin/busybox /usr/sbin/flash_erase /tmp/
+cd /tmp/
+
+killall chrony syslogd klogd uhttpd || true
+
+./flash_erase /dev/mtd3 0 0
+./busybox dd if="$FILE" of=/dev/mtdblock3 bs=65535 conv=fsync
+
+# reboot
+echo b > /proc/sysrq-trigger


### PR DESCRIPTION
Had success with manually executing the steps listed in #21 and figured I'd give a shot at creating a script for it. I've only thus far run this with the last command removed and the previous 3 prefixed with `echo` (so as to not actually do anything). But the output seems reasonable and if there aren't are large changes you'd recommend, I'll run it as-is and validate that it does the right thing.

With no file:

```sh
/tmp # ./fw_upgrade 
error: must pass path to firmware bin or squashfs
usage: ./fw_upgrade ./path/to/firmware.bin
```

With a `bin` file:

```sh
/tmp # ./fw_upgrade postmerkOS-20221115.bin 
8+0 records in
8+0 records out
killall chrony syslogd klogd uhttpd
./flash_erase /dev/mtd3 0 0
./busybox dd if=/tmp/squashfs.EmUs3g of=/dev/mtdblock3 bs=65535 conv=fsync
```

With a `squashfs` file:

```sh
/tmp # ./fw_upgrade rootfs.squashfs 
killall chrony syslogd klogd uhttpd
./flash_erase /dev/mtd3 0 0
./busybox dd if=rootfs.squashfs of=/dev/mtdblock3 bs=65535 conv=fsync
```

With an unknown file:

```sh
/tmp # ./fw_upgrade squashfs.khtwCf 
error: cannot determine input filetype; must have .bin or .squashfs suffix
```
