### PR TITLE
add libpd690xx string functions

### DIFF
--- a/buildroot/packages/pd690xx/Makefile
+++ b/buildroot/packages/pd690xx/Makefile
@@ -4,7 +4,7 @@ PWD=$(shell pwd)
 all: *.c
 	$(CC) -c -Wall -Werror -fpic libpd690xx.c
 	$(CC) -shared -o libpd690xx.so libpd690xx.o
-	$(CC) -L$(PWD) -Wall -o pd690xx pd690xx.c -lpd690xx
+	$(CC) -L$(PWD) -Wall -o pd690xx pd690xx.c -lpd690xx '$<'
 clean:
 	rm -rf a.out pd690xx libpd690xx.0 libpd690xx.so
 	rm -f *.o

--- a/buildroot/packages/pd690xx/libpd690xx.c
+++ b/buildroot/packages/pd690xx/libpd690xx.c
@@ -352,6 +352,19 @@ int port_state(struct pd690xx_cfg *pd690xx, int port) {
     return port_enabled;
 }
 
+char* port_state_str(struct pd690xx_cfg *pd690xx, int port) {
+    switch(port_state(pd690xx, port)) {
+        case PORT_DISABLED:
+            return "Disabled";
+        case PORT_ENABLED:
+            return "Enabled";
+        case PORT_FORCED:
+            return "Forced";
+        default:
+            return "Unknown";
+    }
+}
+
 int port_type(struct pd690xx_cfg *pd690xx, int port) {
     unsigned int res;
     int port_mode = -1;
@@ -375,6 +388,17 @@ int port_type(struct pd690xx_cfg *pd690xx, int port) {
         }
     }
     return port_mode;
+}
+
+char* port_type_str(struct pd690xx_cfg *pd690xx, int port) {
+    switch(port_type(pd690xx, port)) {
+        case PORT_MODE_AF:
+            return "af";
+        case PORT_MODE_AT:
+            return "at";
+        default:
+            return "Unknown";
+    }
 }
 
 int port_priority(struct pd690xx_cfg *pd690xx, int port) {
@@ -405,15 +429,29 @@ int port_priority(struct pd690xx_cfg *pd690xx, int port) {
     return port_prio;
 }
 
-int get_temp(struct pd690xx_cfg *pd690xx) {
+char* port_priority_str(struct pd690xx_cfg *pd690xx, int port) {
+    switch(port_priority(pd690xx, port)) {
+        case PORT_PRIO_CRIT:
+            return "Critical";
+        case PORT_PRIO_HIGH:
+            return "High";
+        case PORT_PRIO_LOW:
+            return "Low";
+        default:
+            return "Unknown";
+    }
+}
+
+float* get_temp(struct pd690xx_cfg *pd690xx) {
     unsigned int res;
     int pd690xx_count = pd690xx_pres_count(pd690xx);
+    float* temps = malloc (sizeof (float) * pd690xx_count);
     for (int i=0; i<pd690xx_count; i++) {
         int i2c_fd = pd690xx_fd(pd690xx, i*12);
         i2c_read(i2c_fd, pd690xx->pd690xx_addrs[i], AVG_JCT_TEMP, &res);
-        printf("%.1f C\n", (((int)res-684)/-1.514)-40);
+        temps[i] = (((int)res-684)/-1.514)-40;
     }
-    return 0;
+    return temps;
 }
 
 int get_power(struct pd690xx_cfg *pd690xx, int port) {

--- a/buildroot/packages/pd690xx/libpd690xx.h
+++ b/buildroot/packages/pd690xx/libpd690xx.h
@@ -85,12 +85,15 @@ int port_disable(struct pd690xx_cfg *pd690xx, int);
 int port_reset(struct pd690xx_cfg *pd690xx, int);
 int port_force(struct pd690xx_cfg *pd690xx, int);
 int port_state(struct pd690xx_cfg *pd690xx, int);
+char* port_state_str(struct pd690xx_cfg *pd690xx, int);
 int port_type(struct pd690xx_cfg *pd690xx, int);
+char* port_type_str(struct pd690xx_cfg *pd690xx, int);
 int get_power(struct pd690xx_cfg *pd690xx, int);
 int get_voltage(struct pd690xx_cfg *pd690xx);
-int get_temp(struct pd690xx_cfg *pd690xx);
+float* get_temp(struct pd690xx_cfg *pd690xx);
 float port_power(struct pd690xx_cfg *pd690xx, int);
 int port_priority(struct pd690xx_cfg *pd690xx, int);
+char* port_priority_str(struct pd690xx_cfg *pd690xx, int);
 void enable_debug(void);
 
 #endif

--- a/buildroot/packages/pd690xx/pd690xx.c
+++ b/buildroot/packages/pd690xx/pd690xx.c
@@ -16,6 +16,14 @@
 
 // Copyright(C) 2020-2022 - Hal Martin <hal.martin@gmail.com>
 
+// print str and then add an extra \t if str is short
+void printf_pad(char* str) {
+    printf("%s\t", str);
+    if (strlen(str) < 8) {
+      printf("\t");
+    }
+}
+
 void list_all(struct pd690xx_cfg *pd690xx) {
     printf("Port\tStatus\t\tType\tPriority\tPower\n");
     int total_ports = 12*pd690xx_pres_count(pd690xx);
@@ -23,44 +31,11 @@ void list_all(struct pd690xx_cfg *pd690xx) {
         // print port number
         printf("%d\t", i);
         // print port status
-        switch(port_state(pd690xx, i)) {
-            case PORT_DISABLED:
-                printf("Disabled\t");
-                break;
-            case PORT_ENABLED:
-                printf("Enabled\t\t");
-                break;
-            case PORT_FORCED:
-                printf("Forced\t\t");
-                break;
-            default:
-                printf("Unknown\t");
-        }
+        printf_pad(port_state_str(pd690xx, i));
         // print port type
-        switch(port_type(pd690xx, i)) {
-            case PORT_MODE_AF:
-                printf("af\t");
-                break;
-            case PORT_MODE_AT:
-                printf("at\t");
-                break;
-            default:
-                printf("Unknown\t");
-        }
+        printf("%s\t", port_type_str(pd690xx, i));
         // print port priority
-        switch(port_priority(pd690xx, i)) {
-            case PORT_PRIO_CRIT:
-                printf("Critical\t");
-                break;
-            case PORT_PRIO_HIGH:
-                printf("High\t\t");
-                break;
-            case PORT_PRIO_LOW:
-                printf("Low\t\t");
-                break;
-            default:
-                printf("Unknown\t");
-        }
+        printf_pad(port_priority_str(pd690xx, i));
         // print port power
         printf("%.1f\n", port_power(pd690xx, i));
     }
@@ -193,7 +168,10 @@ int main (int argc, char **argv) {
         get_voltage(&pd690xx);
     }
     if (temp) {
-        get_temp(&pd690xx);
+        float* temps = get_temp(&pd690xx);
+        for (int i=0; i<sizeof(temps); i++) {
+          printf("%.1f C\n", temps[i]);
+        }
     }
 
     i2c_close(&pd690xx);


### PR DESCRIPTION
These changes move the PoE enum-to-string mappings to the `libpd690xx` package in preparation for use by other packages (e.g., displaying the values in a web UI).